### PR TITLE
Add responsive mobile navigation toggle

### DIFF
--- a/partials/header.html
+++ b/partials/header.html
@@ -1,9 +1,24 @@
 <header class="bg-white shadow-md sticky top-0 z-50">
-  <div class="max-w-screen-xl mx-auto px-6 py-4 flex justify-between items-center">
+  <div class="max-w-screen-xl mx-auto px-6 py-4 flex justify-between items-center relative">
     <a href="/index.html" class="block w-40">
       <img src="/apple-touch-icon.png" alt="Boston SEO Services Logo" class="h-10 w-auto">
     </a>
-    <nav class="hidden md:flex space-x-6 text-sm font-semibold text-gray-700">
+    <button
+      id="menu-toggle"
+      type="button"
+      class="md:hidden inline-flex items-center justify-center p-2 text-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-600"
+      aria-controls="primary-navigation"
+      aria-expanded="false"
+    >
+      <span class="sr-only">Toggle navigation</span>
+      <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
+    <nav
+      id="primary-navigation"
+      class="flex flex-col md:flex-row md:items-center md:space-x-6 space-y-4 md:space-y-0 w-full md:w-auto text-sm font-semibold text-gray-700 bg-white md:bg-transparent absolute md:static top-full left-0 right-0 md:top-auto border-t border-gray-200 md:border-none px-6 md:px-0 py-4 md:py-0 shadow md:shadow-none"
+    >
       <a href="/index.html" class="hover:text-blue-700">Home</a>
       <a href="/blog.html" class="hover:text-blue-700">Blog</a>
       <a href="/contact-us.html" class="hover:text-blue-700">Contact</a>
@@ -11,3 +26,57 @@
     </nav>
   </div>
 </header>
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    var toggleButton = document.getElementById('menu-toggle');
+    var menu = document.getElementById('primary-navigation');
+
+    if (!toggleButton || !menu) {
+      return;
+    }
+
+    var breakpoint = window.matchMedia('(min-width: 768px)');
+
+    function openMenu() {
+      menu.classList.remove('hidden');
+      toggleButton.setAttribute('aria-expanded', 'true');
+    }
+
+    function closeMenu() {
+      menu.classList.add('hidden');
+      toggleButton.setAttribute('aria-expanded', 'false');
+    }
+
+    function syncMenu() {
+      if (breakpoint.matches) {
+        openMenu();
+      } else {
+        closeMenu();
+      }
+    }
+
+    syncMenu();
+
+    toggleButton.addEventListener('click', function () {
+      if (menu.classList.contains('hidden')) {
+        openMenu();
+      } else {
+        closeMenu();
+      }
+    });
+
+    function handleBreakpointChange(event) {
+      if (event.matches) {
+        openMenu();
+      } else {
+        closeMenu();
+      }
+    }
+
+    if (typeof breakpoint.addEventListener === 'function') {
+      breakpoint.addEventListener('change', handleBreakpointChange);
+    } else if (typeof breakpoint.addListener === 'function') {
+      breakpoint.addListener(handleBreakpointChange);
+    }
+  });
+</script>


### PR DESCRIPTION
## Summary
- add a mobile hamburger button and responsive layout tweaks to the header navigation
- implement an accessible script that syncs the menu state with viewport changes and toggle interactions

## Testing
- Playwright responsive menu verification (browser_container)

------
https://chatgpt.com/codex/tasks/task_e_68c8589915b48329ab960f711c586fde