### PR TITLE
Add reusable navigation component

### DIFF
--- a/ai-first-seo-strategies-2025.html
+++ b/ai-first-seo-strategies-2025.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="/assets/nav.css" />
 
   <title>AI First SEO Strategies (2025) | Boston SEO Services</title>
   <meta name="description" content="AI-first SEO playbook for 2025: how to earn citations in Google AI Overviews with schema, speakable summaries, E-E-A-T, FAQs, and step-by-step implementation." />
@@ -259,20 +260,7 @@
 <body>
   <div id="progress" role="presentation" aria-hidden="true"></div>
   <a class="skip-link" href="#main">Skip to content</a>
-
-  <header class="bg-white shadow-md sticky top-0 z-50">
-  <div class="max-w-screen-xl mx-auto px-6 py-4 flex justify-between items-center">
-    <a href="/index.html" class="block w-40">
-      <img src="/apple-touch-icon.png" alt="Boston SEO Services Logo" class="h-10 w-auto">
-    </a>
-    <nav class="hidden md:flex space-x-6 text-sm font-semibold text-gray-700">
-      <a href="/index.html" class="hover:text-blue-700">Home</a>
-      <a href="/blog.html" class="hover:text-blue-700">Blog</a>
-      <a href="/contact-us.html" class="hover:text-blue-700">Contact</a>
-      <a href="/seo-audit.html" class="hover:text-blue-700">Services</a>
-    </nav>
-  </div>
-</header>
+  <header id="site-nav"></header>
 
 
   <main id="main" class="container" aria-label="Main content">
@@ -646,6 +634,8 @@
     );
   });
   -->
+
+  <script type="module" src="/assets/nav.js"></script>
 </body>
 </html>
 

--- a/ai-search-visibility-audit-tool.html
+++ b/ai-search-visibility-audit-tool.html
@@ -7,6 +7,7 @@
     <title>AI Search Visibility Audit Tool – Instantly Find What to Optimize for ChatGPT, Gemini &amp; More</title>
     
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/assets/nav.css" />
     <meta property="og:title" content="AI Search Visibility Audit Tool – Instantly Find What to Optimize for ChatGPT, Gemini &amp; More">
     <meta property="og:description" content="Run a free AI Search Visibility Audit to see how your website performs in AI-generated answers like ChatGPT and Google SGE. Instantly identify what to fix to boost your presence in AI search results.">
     <meta property="og:image" content="https://images.groovetech.io/TNS4tB4BDHN4h71fYHBy_97r7AuY9Qqi62X0zm0W8c4/rs:fit:0:0:0/g:no:0:0/c:0:0/aHR0cHM6Ly9hc3NldHMuZ3Jvb3ZlYXBwcy5jb20vaW1hZ2VzLzVlNjEzMmJjODQ5OTE2MGRjMmNkYjBlNC8xNzUyMDcyNzkwX0NoYXRHUFRJbWFnZUp1bDkyMDI1MTA1MjU4QU0ucG5n.webp">
@@ -138,19 +139,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <link data-gp-stylesheet href="ai-search-visibility-audit-tooldcae.css?v=1.1752177945" rel="stylesheet"/>
         </head>
       <body>
-<header class="bg-white shadow-md sticky top-0 z-50">
-  <div class="max-w-screen-xl mx-auto px-6 py-4 flex justify-between items-center">
-    <a href="/index.html" class="block w-40">
-      <img src="/apple-touch-icon.png" alt="Boston SEO Services Logo" class="h-10 w-auto">
-    </a>
-    <nav class="hidden md:flex space-x-6 text-sm font-semibold text-gray-700">
-      <a href="/index.html" class="hover:text-blue-700">Home</a>
-      <a href="/blog.html" class="hover:text-blue-700">Blog</a>
-      <a href="/contact-us.html" class="hover:text-blue-700">Contact</a>
-      <a href="/seo-audit.html" class="hover:text-blue-700">Services</a>
-    </nav>
-  </div>
-</header>
+<header id="site-nav"></header>
 
         <!-- Start Popups -->
         <script> if(!window.mergeContentSettings) { function mergeContentSettings(){}}</script>
@@ -431,9 +420,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       })();
     </script>
     <script src="../app.groove.cm/groovepages/js/inpage_published.js"></script>
-        
-      
-    
+    <script type="module" src="/assets/nav.js"></script>
     <script defer src="https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015" integrity="sha512-ZpsOmlRQV6y907TI0dKBHq9Md29nnaEIPlkf84rnaERnq6zvWvPUqr2ft8M1aS28oN72PdrCzSjY4U6VaAw1EQ==" data-cf-beacon='{"version":"2024.11.0","token":"0f932c3300764bbebdbcc5225ccae832","r":1,"server_timing":{"name":{"cfCacheStatus":true,"cfEdge":true,"cfExtPri":true,"cfL4":true,"cfOrigin":true,"cfSpeedBrain":true},"location_startswith":null}}' crossorigin="anonymous"></script>
 </body>
 <!-- Mirrored from bostonseoservices.org/ai-search-visibility-audit-tool by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 29 Jul 2025 18:41:57 GMT -->

--- a/assets/nav.css
+++ b/assets/nav.css
@@ -1,0 +1,64 @@
+:root{
+  --bg: #0b1220;
+  --bg-2: #111827;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --brand: #3b82f6;
+  --border: rgba(255,255,255,0.12);
+}
+
+#site-nav{all:unset;display:block;}
+.site-header{background:var(--bg);color:var(--text);position:sticky;top:0;z-index:50;border-bottom:1px solid var(--border);box-shadow:0 1px 0 rgba(15,23,42,0.35);}
+.site-header .inner{max-width:1100px;margin:0 auto;padding:0.75rem 1rem;display:flex;align-items:center;justify-content:space-between;gap:1rem;}
+.brand{display:flex;align-items:center;gap:.5rem;text-decoration:none;color:var(--text);font-weight:600;letter-spacing:.2px;font-size:1.05rem;}
+.brand:focus-visible{outline:2px solid var(--brand);outline-offset:3px;border-radius:.5rem;}
+.brand svg{flex:0 0 auto;}
+
+.menu-toggle{appearance:none;border:1px solid var(--border);background:transparent;color:var(--text);border-radius:.5rem;padding:.5rem .65rem;display:inline-flex;align-items:center;gap:.5rem;cursor:pointer;font-size:0.95rem;transition:background .2s ease,border-color .2s ease;}
+.menu-toggle:hover{background:rgba(255,255,255,0.04);border-color:rgba(255,255,255,0.18);}
+.menu-toggle .bars{width:22px;height:14px;position:relative;display:inline-block;}
+.menu-toggle .bars::before,.menu-toggle .bars::after,.menu-toggle .bar{content:"";position:absolute;left:0;right:0;height:2px;background:var(--text);border-radius:1px;transition:transform .2s ease,opacity .2s ease;}
+.menu-toggle .bar{top:6px;}
+.menu-toggle .bars::before{top:0;}
+.menu-toggle .bars::after{bottom:0;}
+.menu-toggle[aria-expanded="true"] .bars::before{transform:translateY(6px) rotate(45deg);}
+.menu-toggle[aria-expanded="true"] .bars::after{transform:translateY(-6px) rotate(-45deg);}
+.menu-toggle[aria-expanded="true"] .bar{opacity:0;}
+.menu-toggle:focus-visible{outline:2px solid var(--brand);outline-offset:3px;border-radius:.5rem;}
+
+.primary{list-style:none;margin:0;padding:0;border-top:1px solid var(--border);display:flex;flex-direction:column;gap:.25rem;background:var(--bg);}
+.primary > li{position:relative;}
+.primary a,.primary button.dropdown-toggle{display:flex;align-items:center;justify-content:space-between;padding:.85rem 1rem;color:var(--text);text-decoration:none;border-radius:.6rem;font-size:1rem;font-weight:500;background:transparent;border:0;cursor:pointer;transition:background .2s ease,color .2s ease;}
+.primary a:hover,.primary button.dropdown-toggle:hover{background:var(--bg-2);}
+.primary a:focus-visible,.primary button.dropdown-toggle:focus-visible{outline:2px solid var(--brand);outline-offset:2px;}
+.primary a.active,.primary button.dropdown-toggle.active{color:#fff;background:rgba(59,130,246,0.18);}
+
+.dropdown{position:relative;}
+.dropdown .chev{transition:transform .2s ease;flex:0 0 auto;}
+.dropdown[aria-expanded="true"] .chev{transform:rotate(180deg);}
+
+.dropdown-menu{list-style:none;margin:0;padding:.35rem;border:1px solid var(--border);border-radius:.75rem;background:var(--bg-2);display:none;gap:.15rem;box-shadow:0 16px 32px rgba(8,15,35,0.45);}
+.dropdown-menu a{display:block;padding:.6rem .75rem;border-radius:.5rem;}
+.dropdown[aria-expanded="true"] .dropdown-menu{display:block;}
+
+.overlay{position:fixed;inset:0;background:rgba(8,15,35,0.4);display:none;}
+.overlay.show{display:block;backdrop-filter:blur(1px);}
+
+.no-scroll{overflow:hidden;}
+
+.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}
+
+@media (prefers-reduced-motion:reduce){
+  *,*::before,*::after{animation-duration:.001ms !important;animation-iteration-count:1 !important;transition-duration:.001ms !important;scroll-behavior:auto !important;}
+}
+
+@media (min-width:768px){
+  .menu-toggle{display:none;}
+  .site-header nav{max-width:1100px;margin:0 auto;padding:0 1rem 0.75rem;}
+  .primary{border-top:0;flex-direction:row;align-items:center;gap:.35rem;background:transparent;}
+  .primary > li{display:flex;}
+  .primary > li > a,.primary > li > button{padding:.55rem .85rem;font-size:.98rem;}
+  .dropdown-menu{position:absolute;top:calc(100% + 0.45rem);left:0;min-width:260px;padding:.45rem;display:none;}
+  .dropdown:hover .dropdown-menu,.dropdown:focus-within .dropdown-menu{display:block;}
+  .overlay{display:none !important;}
+}

--- a/assets/nav.js
+++ b/assets/nav.js
@@ -1,0 +1,264 @@
+const mount = document.getElementById('site-nav');
+
+if (!mount) {
+  console.warn('Navigation mount point #site-nav not found.');
+} else {
+  const navHTML = `
+    <div class="site-header" role="banner">
+      <div class="inner">
+        <a class="brand" href="/" aria-label="Boston SEO Services home">
+          <svg width="22" height="22" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 3l9 8h-3v9h-5v-6h-2v6H6v-9H3z"></path></svg>
+          <span>Boston SEO Services</span>
+        </a>
+        <button type="button" class="menu-toggle" aria-expanded="false" aria-controls="primary-menu">
+          <span class="bars"><span class="bar"></span></span>
+          <span class="sr-only">Menu</span>
+        </button>
+      </div>
+      <div class="overlay" data-js="overlay" hidden aria-hidden="true"></div>
+      <nav aria-label="Primary navigation">
+        <ul id="primary-menu" class="primary" data-js="menu">
+          <li><a href="/how-ai-search-is-changing-business-2025.html">How AI Search Is Changing Business</a></li>
+          <li><a href="/nyc-seo-services.html">NYC SEO Services</a></li>
+          <li class="dropdown" aria-expanded="false">
+            <button type="button" class="dropdown-toggle" data-js="dropdown-toggle" aria-haspopup="true" aria-expanded="false" aria-controls="ai-guides-submenu">
+              AI Guides
+              <svg class="chev" width="18" height="18" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M7 10l5 5 5-5z"></path></svg>
+            </button>
+            <ul class="dropdown-menu" id="ai-guides-submenu">
+              <li><a href="/ultimate-guide-to-ai-search-optimization.html">Ultimate Guide to AI Search Optimization</a></li>
+              <li><a href="/ai-first-seo-strategies-2025.html">AI-First SEO Strategies 2025</a></li>
+              <li><a href="/ai-search-visibility-audit-tool.html">AI Search Visibility Audit Tool</a></li>
+            </ul>
+          </li>
+          <li><a href="/contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  `;
+
+  mount.innerHTML = navHTML.trim();
+
+  const header = mount.querySelector('.site-header');
+  const menuBtn = header.querySelector('.menu-toggle');
+  const menu = header.querySelector('[data-js="menu"]');
+  const overlay = header.querySelector('[data-js="overlay"]');
+  const dropBtn = header.querySelector('[data-js="dropdown-toggle"]');
+  const dropdown = dropBtn ? dropBtn.closest('.dropdown') : null;
+  const submenu = header.querySelector('#ai-guides-submenu');
+  const brandLink = header.querySelector('.brand');
+
+  const focusableSelectors = 'a[href]:not([tabindex="-1"]), button:not([disabled]):not([aria-hidden="true"]), [tabindex]:not([tabindex="-1"])';
+  const mediaQuery = window.matchMedia('(min-width: 768px)');
+  let lastFocusedElement = null;
+
+  const isDesktop = () => mediaQuery.matches;
+  const isMenuOpen = () => menuBtn.getAttribute('aria-expanded') === 'true';
+  const getFocusableItems = () =>
+    Array.from(menu.querySelectorAll(focusableSelectors)).filter((el) =>
+      el.offsetParent !== null || el.getClientRects().length > 0
+    );
+
+  if (submenu) {
+    submenu.setAttribute('aria-hidden', 'true');
+  }
+
+  const toggleDropdown = (force) => {
+    if (!dropdown || !dropBtn || !submenu) return;
+    const isOpen = dropdown.getAttribute('aria-expanded') === 'true';
+    const shouldOpen = typeof force === 'boolean' ? force : !isOpen;
+    dropdown.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+    dropBtn.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+    submenu.setAttribute('aria-hidden', shouldOpen ? 'false' : 'true');
+    if (shouldOpen) {
+      dropBtn.classList.add('active');
+    } else {
+      dropBtn.classList.remove('active');
+    }
+  };
+
+  const openMenu = () => {
+    if (isDesktop()) return;
+    lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    menu.hidden = false;
+    overlay.hidden = false;
+    overlay.setAttribute('aria-hidden', 'false');
+    overlay.classList.add('show');
+    menuBtn.setAttribute('aria-expanded', 'true');
+    document.body.classList.add('no-scroll');
+    header.dataset.menuState = 'open';
+    const focusables = getFocusableItems();
+    const first = focusables[0];
+    if (first) {
+      requestAnimationFrame(() => first.focus());
+    }
+  };
+
+  const closeMenu = ({ focusToggle = true } = {}) => {
+    menuBtn.setAttribute('aria-expanded', 'false');
+    header.dataset.menuState = 'closed';
+    overlay.classList.remove('show');
+    overlay.hidden = true;
+    overlay.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('no-scroll');
+    if (!isDesktop()) {
+      menu.hidden = true;
+    } else {
+      menu.hidden = false;
+    }
+    toggleDropdown(false);
+    if (focusToggle) {
+      requestAnimationFrame(() => {
+        menuBtn.focus();
+        lastFocusedElement = null;
+      });
+    } else if (lastFocusedElement) {
+      requestAnimationFrame(() => {
+        if (lastFocusedElement) {
+          lastFocusedElement.focus();
+          lastFocusedElement = null;
+        }
+      });
+    } else {
+      lastFocusedElement = null;
+    }
+  };
+
+  const syncMenuToViewport = (event) => {
+    const matches = event?.matches ?? isDesktop();
+    if (matches) {
+      closeMenu({ focusToggle: false });
+      menu.hidden = false;
+    } else if (!isMenuOpen()) {
+      menu.hidden = true;
+    }
+  };
+
+  syncMenuToViewport(mediaQuery);
+  if (typeof mediaQuery.addEventListener === 'function') {
+    mediaQuery.addEventListener('change', syncMenuToViewport);
+  } else if (typeof mediaQuery.addListener === 'function') {
+    mediaQuery.addListener(syncMenuToViewport);
+  }
+
+  menuBtn.addEventListener('click', () => {
+    if (isMenuOpen()) {
+      closeMenu();
+    } else {
+      openMenu();
+    }
+  });
+
+  overlay.addEventListener('click', () => closeMenu());
+
+  menu.addEventListener('click', (event) => {
+    const target = event.target;
+    if (target instanceof HTMLAnchorElement && !isDesktop()) {
+      closeMenu({ focusToggle: false });
+    }
+  });
+
+  const handleKeydown = (event) => {
+    if (event.key === 'Escape') {
+      if (isMenuOpen() && !isDesktop()) {
+        event.preventDefault();
+        closeMenu();
+        return;
+      }
+      if (dropdown && dropdown.getAttribute('aria-expanded') === 'true') {
+        toggleDropdown(false);
+      }
+    }
+
+    if (event.key === 'Tab' && isMenuOpen() && !isDesktop()) {
+      const focusables = getFocusableItems();
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!first || !last) {
+        event.preventDefault();
+        menuBtn.focus();
+        return;
+      }
+      if (event.shiftKey) {
+        if (document.activeElement === first) {
+          event.preventDefault();
+          menuBtn.focus();
+        } else if (document.activeElement === menuBtn) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          event.preventDefault();
+          menuBtn.focus();
+        } else if (document.activeElement === menuBtn) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    }
+  };
+
+  document.addEventListener('keydown', handleKeydown);
+
+  if (dropBtn && dropdown) {
+    dropBtn.addEventListener('click', () => {
+      const isOpen = dropdown.getAttribute('aria-expanded') === 'true';
+      toggleDropdown(!isOpen);
+    });
+
+    dropdown.addEventListener('mouseenter', () => {
+      if (isDesktop()) toggleDropdown(true);
+    });
+    dropdown.addEventListener('mouseleave', () => {
+      if (isDesktop()) toggleDropdown(false);
+    });
+    dropdown.addEventListener('focusin', () => toggleDropdown(true));
+    dropdown.addEventListener('focusout', (event) => {
+      const next = event.relatedTarget;
+      if (!(next instanceof HTMLElement) || !dropdown.contains(next)) {
+        toggleDropdown(false);
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      const target = event.target;
+      if (target instanceof HTMLElement && dropdown && !dropdown.contains(target)) {
+        toggleDropdown(false);
+      }
+    });
+  }
+
+  const setActiveLink = () => {
+    const normalisePath = (path) => {
+      if (!path) return '/';
+      const url = new URL(path, window.location.origin);
+      let pathname = url.pathname.toLowerCase();
+      pathname = pathname.replace(/index\.html?$/i, '/');
+      pathname = pathname.replace(/\/+$/, '');
+      return pathname || '/';
+    };
+
+    const currentPath = normalisePath(window.location.pathname);
+    const links = header.querySelectorAll('a[href]');
+    links.forEach((link) => {
+      const linkPath = normalisePath(link.getAttribute('href'));
+      if (linkPath === currentPath) {
+        link.classList.add('active');
+      }
+    });
+
+    if (dropdown && submenu && submenu.querySelector('a.active')) {
+      dropBtn.classList.add('active');
+    }
+
+    if (brandLink) {
+      const homePaths = ['/', '/index.html', '/index.htm'];
+      if (homePaths.includes(currentPath)) {
+        brandLink.classList.add('active');
+      }
+    }
+  };
+
+  setActiveLink();
+}

--- a/contact.html
+++ b/contact.html
@@ -3,6 +3,7 @@
 <head>
     <link href="https://unpkg.com/tailwindcss@^1.0/dist/tailwind.min.css" rel="stylesheet">
     <link rel="shortcut icon" href="https://assets.grooveapps.com/other/favicon-32x32.png">
+    <link rel="stylesheet" href="/assets/nav.css" />
     <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:300,400,600,700&display=swap" rel="stylesheet">
     <style>
     body {
@@ -15,19 +16,7 @@
 <title>GroovePages</title>
 </head>
 <body>
-<header class="bg-white shadow-md sticky top-0 z-50">
-  <div class="max-w-screen-xl mx-auto px-6 py-4 flex justify-between items-center">
-    <a href="/index.html" class="block w-40">
-      <img src="/apple-touch-icon.png" alt="Boston SEO Services Logo" class="h-10 w-auto">
-    </a>
-    <nav class="hidden md:flex space-x-6 text-sm font-semibold text-gray-700">
-      <a href="/index.html" class="hover:text-blue-700">Home</a>
-      <a href="/blog.html" class="hover:text-blue-700">Blog</a>
-      <a href="/contact-us.html" class="hover:text-blue-700">Contact</a>
-      <a href="/seo-audit.html" class="hover:text-blue-700">Services</a>
-    </nav>
-  </div>
-</header>
+<header id="site-nav"></header>
 
 	<div class="w-screen h-screen flex flex-col items-center justify-center hidden" id="inline404">
 		<p class="text-white text-5xl text-center tracking-wide">
@@ -71,5 +60,6 @@
 		fetch404();
 	</script>
 <script defer src="https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015" integrity="sha512-ZpsOmlRQV6y907TI0dKBHq9Md29nnaEIPlkf84rnaERnq6zvWvPUqr2ft8M1aS28oN72PdrCzSjY4U6VaAw1EQ==" data-cf-beacon='{"version":"2024.11.0","token":"0f932c3300764bbebdbcc5225ccae832","r":1,"server_timing":{"name":{"cfCacheStatus":true,"cfEdge":true,"cfExtPri":true,"cfL4":true,"cfOrigin":true,"cfSpeedBrain":true},"location_startswith":null}}' crossorigin="anonymous"></script>
+<script type="module" src="/assets/nav.js"></script>
 </body>
 </html>

--- a/how-ai-search-is-changing-business-2025.html
+++ b/how-ai-search-is-changing-business-2025.html
@@ -10,6 +10,7 @@
   <meta name="theme-color" content="#155eef" />
   <meta name="format-detection" content="telephone=no" />
   <link rel="canonical" href="https://bostonseoservices.org/how-ai-search-is-changing-business-2025.html" />
+  <link rel="stylesheet" href="/assets/nav.css" />
 
   <!-- Social cards -->
   <meta property="og:type" content="article" />
@@ -62,19 +63,7 @@
 </head>
 <body>
   <a href="#main" class="skip-link">Skip to content</a>
-  <header class="bg-white shadow-md sticky top-0 z-50">
-  <div class="max-w-screen-xl mx-auto px-6 py-4 flex justify-between items-center">
-    <a href="/index.html" class="block w-40">
-      <img src="/apple-touch-icon.png" alt="Boston SEO Services Logo" class="h-10 w-auto">
-    </a>
-    <nav class="hidden md:flex space-x-6 text-sm font-semibold text-gray-700">
-      <a href="/index.html" class="hover:text-blue-700">Home</a>
-      <a href="/blog.html" class="hover:text-blue-700">Blog</a>
-      <a href="/contact-us.html" class="hover:text-blue-700">Contact</a>
-      <a href="/seo-audit.html" class="hover:text-blue-700">Services</a>
-    </nav>
-  </div>
-</header>
+  <header id="site-nav"></header>
 
 
   <section class="wrap" aria-label="Quick Answer">
@@ -329,5 +318,6 @@
     </script>
 
   </main>
+  <script type="module" src="/assets/nav.js"></script>
 </body>
 </html>

--- a/nyc-seo-services.html
+++ b/nyc-seo-services.html
@@ -7,6 +7,7 @@
     <title>NYC SEO Services | New York City Local SEO, Ecommerce, Web Design, Social Media</title>
     
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/assets/nav.css" />
     <meta property="og:title" content="Boston SEO Services | Local Search Engine Optimization">
     <meta property="og:description" content="">
     <meta property="og:image" content="https://images.groovetech.io/ZFpv3ZXf7ekLEq5di1edHUARfV7kgkjcQUiQF3mfhTs/rs:fit:0:0:0/g:no:0:0/c:0:0/aHR0cHM6Ly9hc3NldHMuZ3Jvb3ZlYXBwcy5jb20vaW1hZ2VzLzVlNjEzMmJjODQ5OTE2MGRjMmNkYjBlNC8xNzUyNzc5MTY0X0NoYXRHUFRJbWFnZUp1bDE3MjAyNTAzMDU0NFBNLnBuZw.webp">
@@ -5324,23 +5325,10 @@ Let’s discuss how to improve your rankings, leads, and ROI — risk-free.&lt;/
 <link data-gp-stylesheet href="nyc-seo-services8ea3.css?v=1.1752781407" rel="stylesheet"/>
         </head>
 <body>
-    
+
+    <header id="site-nav"></header>
+
     <div class="reading-progress" id="reading-progress"></div>
-    
-    
-    <header class="bg-white shadow-md sticky top-0 z-50">
-  <div class="max-w-screen-xl mx-auto px-6 py-4 flex justify-between items-center">
-    <a href="/index.html" class="block w-40">
-      <img src="/apple-touch-icon.png" alt="Boston SEO Services Logo" class="h-10 w-auto">
-    </a>
-    <nav class="hidden md:flex space-x-6 text-sm font-semibold text-gray-700">
-      <a href="/index.html" class="hover:text-blue-700">Home</a>
-      <a href="/blog.html" class="hover:text-blue-700">Blog</a>
-      <a href="/contact-us.html" class="hover:text-blue-700">Contact</a>
-      <a href="/seo-audit.html" class="hover:text-blue-700">Services</a>
-    </nav>
-  </div>
-</header>
 
     
     
@@ -6288,6 +6276,7 @@ Let’s discuss how to improve your rankings, leads, and ROI — risk-free.</p>
         
     </script>
 <script defer src="https://static.cloudflareinsights.com/beacon.min.js/vcd15cbe7772f49c399c6a5babf22c1241717689176015" integrity="sha512-ZpsOmlRQV6y907TI0dKBHq9Md29nnaEIPlkf84rnaERnq6zvWvPUqr2ft8M1aS28oN72PdrCzSjY4U6VaAw1EQ==" data-cf-beacon='{"version":"2024.11.0","token":"0f932c3300764bbebdbcc5225ccae832","r":1,"server_timing":{"name":{"cfCacheStatus":true,"cfEdge":true,"cfExtPri":true,"cfL4":true,"cfOrigin":true,"cfSpeedBrain":true},"location_startswith":null}}' crossorigin="anonymous"></script>
+<script type="module" src="/assets/nav.js"></script>
 </body>
 
 <!-- Mirrored from bostonseoservices.org/nyc-seo-services by HTTrack Website Copier/3.x [XR&CO'2014], Tue, 29 Jul 2025 18:42:16 GMT -->
@@ -6315,7 +6304,4 @@ Let’s discuss how to improve your rankings, leads, and ROI — risk-free.</p>
       })();
     </script>
     <script src="../app.groove.cm/groovepages/js/inpage_published.js"></script>
-        
-      
-    
     </body></html>

--- a/ultimate-guide-to-ai-search-optimization.html
+++ b/ultimate-guide-to-ai-search-optimization.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>The Ultimate Guide to AI Search Optimization | Boston SEO Services</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/assets/nav.css" />
   <link rel="canonical" href="https://bostonseoservices.org/ultimate-guide-to-ai-search-optimization.html">
   <meta name="robots" content="index,follow,max-image-preview:large">
   <meta name="revisit-after" content="7 days">
@@ -50,19 +51,7 @@
   </style>
 </head>
 <body>
-<header class="bg-white shadow-md sticky top-0 z-50">
-  <div class="max-w-screen-xl mx-auto px-6 py-4 flex justify-between items-center">
-    <a href="/index.html" class="block w-40">
-      <img src="/apple-touch-icon.png" alt="Boston SEO Services Logo" class="h-10 w-auto">
-    </a>
-    <nav class="hidden md:flex space-x-6 text-sm font-semibold text-gray-700">
-      <a href="/index.html" class="hover:text-blue-700">Home</a>
-      <a href="/blog.html" class="hover:text-blue-700">Blog</a>
-      <a href="/contact-us.html" class="hover:text-blue-700">Contact</a>
-      <a href="/seo-audit.html" class="hover:text-blue-700">Services</a>
-    </nav>
-  </div>
-</header>
+<header id="site-nav"></header>
 
   <!-- HERO uses the same URL as OG/Twitter -->
   <div class="ai-hero">
@@ -450,5 +439,6 @@
     ]
   }
   </script>
+  <script type="module" src="/assets/nav.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add shared navigation stylesheet and script to render an accessible, responsive primary menu with dropdown support
- replace inline navigation markup on key HTML pages with the shared #site-nav mount and module loader

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c962122aac832989327029de776c9d